### PR TITLE
DEV-18054 Pudo service point ID adjustments

### DIFF
--- a/src/Api/Data/Request/RecipientInterface.php
+++ b/src/Api/Data/Request/RecipientInterface.php
@@ -74,4 +74,9 @@ interface RecipientInterface
 	 * @return string
 	 */
 	public function getStateOrProvince();
+
+	/**
+	 * @return string|null
+	 */
+	public function getMobilePhone();
 }

--- a/src/Api/Data/Request/Shipment/ShipperInterface.php
+++ b/src/Api/Data/Request/Shipment/ShipperInterface.php
@@ -74,4 +74,9 @@ interface ShipperInterface
 	 * @return string
 	 */
 	public function getStateOrProvince();
+
+	/**
+	 * @return string|null
+	 */
+	public function getMobilePhone();
 }

--- a/src/Api/Data/ShipmentRequestInterface.php
+++ b/src/Api/Data/ShipmentRequestInterface.php
@@ -13,6 +13,8 @@ use Dhl\Express\Api\Data\Request\Shipment\DangerousGoods\DryIceInterface;
 use Dhl\Express\Api\Data\Request\Shipment\ShipmentDetailsInterface;
 use Dhl\Express\Api\Data\Request\Shipment\ShipperInterface;
 use Dhl\Express\Model\Request\InternationalDetail;
+use Dhl\Express\Model\ShipmentRequest;
+use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\OnDemandDeliveryOptions;
 
 /**
  * Shipment Request Interface.
@@ -67,7 +69,28 @@ interface ShipmentRequestInterface
 	public function getDryIce();
 
 	/**
+	 * Sets the dry ice instance.
+	 *
+	 * @param DryIceInterface $dryIce The dry ice instance
+	 *
+	 * @return ShipmentRequest
+	 */
+	public function setDryIce(DryIceInterface $dryIce);
+
+	/**
 	 * @return InternationalDetailInterface|null
 	 */
 	public function getInternationalDetail();
+
+	/**
+	 * @return OnDemandDeliveryOptions|null
+	 */
+	public function getOnDemandDeliveryOptions();
+
+	/**
+	 * @param OnDemandDeliveryOptions $onDemandDeliveryOptions
+	 *
+	 * @return $this
+	 */
+	public function setOnDemandDeliveryOptions(OnDemandDeliveryOptions $onDemandDeliveryOptions);
 }

--- a/src/Api/Data/ShipmentRequestInterface.php
+++ b/src/Api/Data/ShipmentRequestInterface.php
@@ -12,9 +12,7 @@ use Dhl\Express\Api\Data\Request\RecipientInterface;
 use Dhl\Express\Api\Data\Request\Shipment\DangerousGoods\DryIceInterface;
 use Dhl\Express\Api\Data\Request\Shipment\ShipmentDetailsInterface;
 use Dhl\Express\Api\Data\Request\Shipment\ShipperInterface;
-use Dhl\Express\Model\Request\InternationalDetail;
 use Dhl\Express\Model\ShipmentRequest;
-use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\OnDemandDeliveryOptions;
 
 /**
  * Shipment Request Interface.
@@ -83,14 +81,14 @@ interface ShipmentRequestInterface
 	public function getInternationalDetail();
 
 	/**
-	 * @return OnDemandDeliveryOptions|null
+	 * @return string|null
 	 */
-	public function getOnDemandDeliveryOptions();
+	public function getOnDemandDeliveryServicePoint();
 
 	/**
-	 * @param OnDemandDeliveryOptions $onDemandDeliveryOptions
+	 * @param string $servicePoint
 	 *
 	 * @return $this
 	 */
-	public function setOnDemandDeliveryOptions(OnDemandDeliveryOptions $onDemandDeliveryOptions);
+	public function setOnDemandDeliveryServicePoint($servicePoint);
 }

--- a/src/Api/ShipmentRequestBuilderInterface.php
+++ b/src/Api/ShipmentRequestBuilderInterface.php
@@ -135,6 +135,7 @@ interface ShipmentRequestBuilderInterface
 	 * @param string $name
 	 * @param string $company
 	 * @param string $phone
+	 * @param string|null $mobilePhone
 	 * @param string|null $email
 	 *
 	 * @return ShipmentRequestBuilderInterface
@@ -147,6 +148,7 @@ interface ShipmentRequestBuilderInterface
 		$name,
 		$company,
 		$phone,
+		$mobilePhone = null,
 		$email = null
 	);
 
@@ -160,6 +162,7 @@ interface ShipmentRequestBuilderInterface
 	 * @param string $name
 	 * @param string $company
 	 * @param string $phone
+	 * @param string|null $mobilePhone
 	 * @param string|null $email
 	 *
 	 * @return ShipmentRequestBuilderInterface
@@ -172,6 +175,7 @@ interface ShipmentRequestBuilderInterface
 		$name,
 		$company,
 		$phone,
+		$mobilePhone = null,
 		$email = null
 	);
 
@@ -235,6 +239,13 @@ interface ShipmentRequestBuilderInterface
 		$recepientReference,
 		$exportItems
 	);
+
+	/**
+	 * @param string $servicePointId
+	 *
+	 * @return ShipmentRequestBuilderInterface
+	 */
+	public function setOnDemandDelivery(string $servicePointId);
 
 	/**
 	 * Builds the shipment request instance.

--- a/src/Api/ShipmentRequestBuilderInterface.php
+++ b/src/Api/ShipmentRequestBuilderInterface.php
@@ -245,7 +245,7 @@ interface ShipmentRequestBuilderInterface
 	 *
 	 * @return ShipmentRequestBuilderInterface
 	 */
-	public function setOnDemandDelivery(string $servicePointId);
+	public function setOnDemandDeliveryServicePoint($servicePointId);
 
 	/**
 	 * Builds the shipment request instance.

--- a/src/Model/Request/Recipient.php
+++ b/src/Model/Request/Recipient.php
@@ -76,6 +76,11 @@ class Recipient implements RecipientInterface
 	 */
 	private $stateOrProvince;
 
+	/**
+	 * @var string|null
+	 */
+	private $mobilePhone;
+
     /**
      * Recipient constructor.
      *
@@ -86,6 +91,7 @@ class Recipient implements RecipientInterface
      * @param string $name
      * @param string $company
      * @param string $phone
+     * @param string|null $mobilePhone
      * @param string|null $email
      * @param string|null $stateOrProvince
      */
@@ -97,6 +103,7 @@ class Recipient implements RecipientInterface
         $name,
         $company,
         $phone,
+		$mobilePhone = null,
         $email = null,
         $stateOrProvince = null
     ) {
@@ -107,6 +114,7 @@ class Recipient implements RecipientInterface
         $this->name = $name;
         $this->company = $company;
         $this->phone = $phone;
+		$this->mobilePhone = $mobilePhone;
         $this->email = $email;
 	    $this->stateOrProvince = $stateOrProvince;
     }
@@ -154,5 +162,10 @@ class Recipient implements RecipientInterface
 	public function getStateOrProvince()
 	{
 		return (string) $this->stateOrProvince;
+	}
+
+	public function getMobilePhone()
+	{
+		return $this->mobilePhone;
 	}
 }

--- a/src/Model/Request/Shipment/Shipper.php
+++ b/src/Model/Request/Shipment/Shipper.php
@@ -76,6 +76,11 @@ class Shipper implements ShipperInterface
 	 */
 	private $stateOrProvince;
 
+	/**
+	 * @var string|null
+	 */
+	private $mobilePhone;
+
     /**
      * Shipper constructor.
      *
@@ -86,6 +91,7 @@ class Shipper implements ShipperInterface
      * @param string $name
      * @param string $company
      * @param string $phone
+     * @param string|null $mobilePhone
      * @param string|null $email
      * @param string|null $stateOrProvince
      */
@@ -97,6 +103,7 @@ class Shipper implements ShipperInterface
         $name,
         $company,
         $phone,
+        $mobilePhone = null,
         $email = null,
         $stateOrProvince = null
     ) {
@@ -107,6 +114,7 @@ class Shipper implements ShipperInterface
         $this->name = $name;
         $this->company = $company;
         $this->phone = $phone;
+		$this->mobilePhone = $mobilePhone;
         $this->email = $email;
         $this->stateOrProvince = $stateOrProvince;
     }
@@ -154,5 +162,10 @@ class Shipper implements ShipperInterface
 	public function getStateOrProvince()
 	{
         return (string) $this->stateOrProvince;
+	}
+
+	public function getMobilePhone()
+	{
+		return $this->mobilePhone;
 	}
 }

--- a/src/Model/ShipmentRequest.php
+++ b/src/Model/ShipmentRequest.php
@@ -13,7 +13,6 @@ use Dhl\Express\Api\Data\ShipmentRequestInterface;
 use Dhl\Express\Model\Request\InternationalDetail;
 use Dhl\Express\Model\Request\Recipient;
 use Dhl\Express\Model\Request\Shipment\Shipper;
-use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\OnDemandDeliveryOptions;
 
 /**
  * Shipment Request.
@@ -69,9 +68,9 @@ class ShipmentRequest implements ShipmentRequestInterface
 	private $dryIce;
 
 	/**
-	 * @var OnDemandDeliveryOptions|null
+	 * @var string|null
 	 */
-	private $onDemandDeliveryOptions;
+	private $onDemandDeliveryServicePoint;
 
 	/**
 	 * SoapShipmentRequest constructor.
@@ -89,7 +88,7 @@ class ShipmentRequest implements ShipmentRequestInterface
 		Shipper $shipper,
 		Recipient $recipient,
 		array $packages,
-		?InternationalDetail $internationalDetail
+		$internationalDetail = null
 	) {
 		$this->shipmentDetails = $shipmentDetails;
 		$this->payerAccountNumber = $payerAccountNumber;
@@ -189,14 +188,14 @@ class ShipmentRequest implements ShipmentRequestInterface
 		return $this->internationalDetail;
 	}
 
-	public function getOnDemandDeliveryOptions()
+	public function getOnDemandDeliveryServicePoint()
 	{
-		return $this->onDemandDeliveryOptions;
+		return $this->onDemandDeliveryServicePoint;
 	}
 
-	public function setOnDemandDeliveryOptions(OnDemandDeliveryOptions $onDemandDeliveryOptions)
+	public function setOnDemandDeliveryServicePoint($servicePointId)
 	{
-		$this->onDemandDeliveryOptions = $onDemandDeliveryOptions;
+		$this->onDemandDeliveryServicePoint = $servicePointId;
 
 		return $this;
 	}

--- a/src/Model/ShipmentRequest.php
+++ b/src/Model/ShipmentRequest.php
@@ -13,6 +13,7 @@ use Dhl\Express\Api\Data\ShipmentRequestInterface;
 use Dhl\Express\Model\Request\InternationalDetail;
 use Dhl\Express\Model\Request\Recipient;
 use Dhl\Express\Model\Request\Shipment\Shipper;
+use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\OnDemandDeliveryOptions;
 
 /**
  * Shipment Request.
@@ -66,6 +67,11 @@ class ShipmentRequest implements ShipmentRequestInterface
 	 * @var null|DryIceInterface
 	 */
 	private $dryIce;
+
+	/**
+	 * @var OnDemandDeliveryOptions|null
+	 */
+	private $onDemandDeliveryOptions;
 
 	/**
 	 * SoapShipmentRequest constructor.
@@ -181,5 +187,17 @@ class ShipmentRequest implements ShipmentRequestInterface
 	public function getInternationalDetail()
 	{
 		return $this->internationalDetail;
+	}
+
+	public function getOnDemandDeliveryOptions()
+	{
+		return $this->onDemandDeliveryOptions;
+	}
+
+	public function setOnDemandDeliveryOptions(OnDemandDeliveryOptions $onDemandDeliveryOptions)
+	{
+		$this->onDemandDeliveryOptions = $onDemandDeliveryOptions;
+
+		return $this;
 	}
 }

--- a/src/RequestBuilder/ShipmentRequestBuilder.php
+++ b/src/RequestBuilder/ShipmentRequestBuilder.php
@@ -411,17 +411,9 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 		return $this;
 	}
 
-	public function setOnDemandDelivery(string $servicePointId)
+	public function setOnDemandDeliveryServicePoint($servicePointId)
 	{
-		$this->data['onDemandDelivery'] = new OnDemandDeliveryOptions(
-			OnDemandDeliveryOptions\DeliveryOption::TV,
-			null,
-			null,
-			null,
-			null,
-			null,
-			$servicePointId
-		);
+		$this->data['onDemandDeliveryServicePoint'] = $servicePointId;
 
 		return $this;
 	}
@@ -551,8 +543,8 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 			$request->setDryIce($dryIce);
 		}
 
-		if (isset($this->data['onDemandDelivery'])) {
-			$request->setOnDemandDeliveryOptions($this->data['onDemandDelivery']);
+		if (isset($this->data['onDemandDeliveryServicePoint'])) {
+			$request->setOnDemandDeliveryServicePoint($this->data['onDemandDeliveryServicePoint']);
 		}
 
 		$this->data = [];

--- a/src/RequestBuilder/ShipmentRequestBuilder.php
+++ b/src/RequestBuilder/ShipmentRequestBuilder.php
@@ -15,6 +15,7 @@ use Dhl\Express\Model\Request\Shipment\DangerousGoods\DryIce;
 use Dhl\Express\Model\Request\Shipment\ShipmentDetails;
 use Dhl\Express\Model\Request\Shipment\Shipper;
 use Dhl\Express\Model\ShipmentRequest;
+use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\OnDemandDeliveryOptions;
 
 /**
  * Shipment Request Builder.
@@ -323,6 +324,7 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 		$name,
 		$company,
 		$phone,
+		$mobilePhone = null,
 		$email = null,
 		$stateOrProvince = null
 	)
@@ -335,6 +337,7 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 			'name'            => $name,
 			'company'         => $company,
 			'phone'           => $phone,
+			'mobilePhone'     => $mobilePhone,
 			'email'           => $email,
 			'stateOrProvince' => $stateOrProvince,
 		];
@@ -350,6 +353,7 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 		$name,
 		$company,
 		$phone,
+		$mobilePhone = null,
 		$email = null,
 		$stateOrProvince = null
 	)
@@ -362,6 +366,7 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 			'name'            => $name,
 			'company'         => $company,
 			'phone'           => $phone,
+			'mobilePhone'     => $mobilePhone,
 			'email'           => $email,
 			'stateOrProvince' => $stateOrProvince,
 		];
@@ -406,6 +411,21 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 		return $this;
 	}
 
+	public function setOnDemandDelivery(string $servicePointId)
+	{
+		$this->data['onDemandDelivery'] = new OnDemandDeliveryOptions(
+			OnDemandDeliveryOptions\DeliveryOption::TV,
+			null,
+			null,
+			null,
+			null,
+			null,
+			$servicePointId
+		);
+
+		return $this;
+	}
+
 	public function build()
 	{
 		// Build shipment details
@@ -432,6 +452,7 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 			$this->data['shipper']['name'],
 			$this->data['shipper']['company'],
 			$this->data['shipper']['phone'],
+			$this->data['shipper']['mobilePhone'],
 			$this->data['shipper']['email'],
 			$this->data['shipper']['stateOrProvince']
 		);
@@ -445,6 +466,7 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 			$this->data['recipient']['name'],
 			$this->data['recipient']['company'],
 			$this->data['recipient']['phone'],
+			$this->data['recipient']['mobilePhone'],
 			$this->data['recipient']['email'],
 			$this->data['recipient']['stateOrProvince']
 		);
@@ -527,6 +549,10 @@ class ShipmentRequestBuilder implements ShipmentRequestBuilderInterface
 			);
 
 			$request->setDryIce($dryIce);
+		}
+
+		if (isset($this->data['onDemandDelivery'])) {
+			$request->setOnDemandDeliveryOptions($this->data['onDemandDelivery']);
 		}
 
 		$this->data = [];

--- a/src/Webservice/Soap/Type/Common/SpecialServices/ServiceType.php
+++ b/src/Webservice/Soap/Type/Common/SpecialServices/ServiceType.php
@@ -24,6 +24,8 @@ class ServiceType implements ValueInterface
     const TYPE_PAPERLESS = 'WY';
     const TYPE_DOCUMENT_INSURANCE = 'IB';
 
+	const TYPE_ON_DEMAND_DELIVERY = 'TV';
+
     /**
      * The service type.
      *

--- a/src/Webservice/Soap/Type/ShipmentRequest/OnDemandDeliveryOptions.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/OnDemandDeliveryOptions.php
@@ -148,11 +148,15 @@ class OnDemandDeliveryOptions
             }
         }
 
-        if ($deliveryOption === DeliveryOption::TV && empty($selectedServicePointId)) {
-            throw new \InvalidArgumentException(
-                'The selected service point id is required for selected delivery option'
-            );
-        }
+	    if ($deliveryOption === DeliveryOption::TV) {
+		    if (empty($selectedServicePointId)) {
+			    throw new \InvalidArgumentException(
+				    'The selected service point id is required for selected delivery option: ' . DeliveryOption::TV
+			    );
+		    }
+
+		    $this->setSelectedServicePointId($selectedServicePointId);
+	    }
     }
 
     /**
@@ -175,6 +179,7 @@ class OnDemandDeliveryOptions
     public function setDeliveryOption($deliveryOption)
     {
         $this->DeliveryOption = new DeliveryOption($deliveryOption);
+
         return $this;
     }
 
@@ -198,6 +203,7 @@ class OnDemandDeliveryOptions
     public function setLocation($location)
     {
         $this->Location = new Location($location);
+
         return $this;
     }
 
@@ -221,6 +227,7 @@ class OnDemandDeliveryOptions
     public function setInstructions($instructions)
     {
         $this->Instructions = new Instructions($instructions);
+
         return $this;
     }
 
@@ -244,6 +251,7 @@ class OnDemandDeliveryOptions
     public function setGateCode($gateCode)
     {
         $this->GateCode = new GateCode($gateCode);
+
         return $this;
     }
 
@@ -267,6 +275,7 @@ class OnDemandDeliveryOptions
     public function setLWNTypeCode($lwnTypeCode)
     {
         $this->LWNTypeCode = new LWNTypeCode($lwnTypeCode);
+
         return $this;
     }
 
@@ -290,6 +299,7 @@ class OnDemandDeliveryOptions
     public function setNeighbourName($neighbourName)
     {
         $this->NeighbourName = new NeighbourName($neighbourName);
+
         return $this;
     }
 
@@ -313,6 +323,7 @@ class OnDemandDeliveryOptions
     public function setNeighbourHouseNumber($neighbourHouseNumber)
     {
         $this->NeighbourHouseNumber = new NeighbourHouseNumber($neighbourHouseNumber);
+
         return $this;
     }
 
@@ -336,6 +347,7 @@ class OnDemandDeliveryOptions
     public function setAuthorizerName($name)
     {
         $this->AuthorizerName = new AuthorizerName($name);
+
         return $this;
     }
 
@@ -359,6 +371,7 @@ class OnDemandDeliveryOptions
     public function setSelectedServicePointId($selectedServicePointId)
     {
         $this->SelectedServicePointID = new SelectedServicePointId($selectedServicePointId);
+
         return $this;
     }
 
@@ -382,6 +395,7 @@ class OnDemandDeliveryOptions
     public function setRequestedDeliveryDate($requestedDeliveryDate)
     {
         $this->RequestedDeliveryDate = new RequestedDeliveryDate($requestedDeliveryDate);
+
         return $this;
     }
 }

--- a/src/Webservice/Soap/Type/ShipmentRequest/RequestedShipment.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/RequestedShipment.php
@@ -5,10 +5,8 @@
 
 namespace Dhl\Express\Webservice\Soap\Type\ShipmentRequest;
 
-use Dhl\Express\Webservice\Soap\Type\Common\AlphaNumeric;
 use Dhl\Express\Webservice\Soap\Type\Common\PaymentInfo;
 use Dhl\Express\Webservice\Soap\Type\Common\ShipTimestamp;
-use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\ExportDeclaration;
 
 /**
  * The requested shipment.
@@ -101,7 +99,7 @@ class RequestedShipment
 		ShipmentInfo $shipmentInfo,
 		$shipTimestamp,
 		$paymentInfo,
-		?InternationalDetail $internationalDetail,
+		$internationalDetail,
 		Ship $ship,
 		Packages $packages
 	) {

--- a/src/Webservice/Soap/Type/ShipmentRequest/Ship.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/Ship.php
@@ -54,17 +54,22 @@ class Ship
      */
     private $Recipient;
 
-    /**
-     * Constructs the ship section.
-     *
-     * @param ContactInfo $shipper   The shipper contact info
-     * @param ContactInfo $recipient The recipient contact info
-     */
-    public function __construct(ContactInfo $shipper, ContactInfo $recipient)
-    {
-        $this->setShipper($shipper)
-            ->setRecipient($recipient);
-    }
+	/**
+	 * Constructs the ship section.
+	 *
+	 * @param ContactInfo      $shipper   The shipper contact info
+	 * @param ContactInfo      $recipient The recipient contact info
+	 * @param BuyerContactInfo $buyer     Needed in some requests
+	 */
+	public function __construct(ContactInfo $shipper, ContactInfo $recipient, BuyerContactInfo $buyer = null)
+	{
+		$this->setShipper($shipper)
+			->setRecipient($recipient);
+
+		if ($buyer) {
+			$this->setBuyer($buyer);
+		}
+	}
 
     /**
      * Returns the shipper contact info.
@@ -86,6 +91,7 @@ class Ship
     public function setShipper(ContactInfo $contactInfo)
     {
         $this->Shipper = $contactInfo;
+
         return $this;
     }
 
@@ -109,6 +115,7 @@ class Ship
     public function setPickup(ContactInfo $contactInfo)
     {
         $this->Pickup = $contactInfo;
+
         return $this;
     }
 
@@ -132,6 +139,7 @@ class Ship
     public function setBookingRequestor(ContactInfo $contactInfo)
     {
         $this->BookingRequestor = $contactInfo;
+
         return $this;
     }
 
@@ -155,6 +163,7 @@ class Ship
     public function setBuyer(BuyerContactInfo $contactInfo)
     {
         $this->Buyer = $contactInfo;
+
         return $this;
     }
 
@@ -178,6 +187,7 @@ class Ship
     public function setRecipient(ContactInfo $contactInfo)
     {
         $this->Recipient = $contactInfo;
+
         return $this;
     }
 }

--- a/src/Webservice/Soap/Type/ShipmentRequest/Ship/BuyerContactInfo.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/Ship/BuyerContactInfo.php
@@ -16,7 +16,7 @@ class BuyerContactInfo
     /**
      * The contact.
      *
-     * @var BuyerContact
+     * @var Contact
      */
     private $Contact;
 
@@ -30,10 +30,10 @@ class BuyerContactInfo
     /**
      * Constructor.
      *
-     * @param BuyerContact $contact The buyer contact
+     * @param Contact $contact The buyer contact
      * @param BuyerAddress $address The buyer address
      */
-    public function __construct(BuyerContact $contact, BuyerAddress $address)
+    public function __construct(Contact $contact, BuyerAddress $address)
     {
         $this->setContact($contact)
             ->setAddress($address);
@@ -42,7 +42,7 @@ class BuyerContactInfo
     /**
      * Returns the buyer contact.
      *
-     * @return BuyerContact
+     * @return Contact
      */
     public function getContact()
     {
@@ -52,13 +52,14 @@ class BuyerContactInfo
     /**
      * Sets the buyer contact.
      *
-     * @param BuyerContact $contact The contact.
+     * @param Contact $contact The contact.
      *
      * @return self
      */
-    public function setContact(BuyerContact $contact)
+    public function setContact(Contact $contact)
     {
         $this->Contact = $contact;
+
         return $this;
     }
 
@@ -82,6 +83,7 @@ class BuyerContactInfo
     public function setAddress(BuyerAddress $address)
     {
         $this->Address = $address;
+
         return $this;
     }
 }

--- a/src/Webservice/Soap/Type/ShipmentRequest/Ship/Contact.php
+++ b/src/Webservice/Soap/Type/ShipmentRequest/Ship/Contact.php
@@ -44,19 +44,28 @@ class Contact
      */
     private $MobilePhoneNumber;
 
-    /**
-     * Constructor.
-     *
-     * @param string $personName  The person name
-     * @param string $companyName The company name
-     * @param string $phoneNumber The phone number
-     */
-    public function __construct($personName, $companyName, $phoneNumber)
-    {
-        $this->setPersonName($personName)
-            ->setCompanyName($companyName)
-            ->setPhoneNumber($phoneNumber);
-    }
+	/**
+	 * @param string $personName
+	 * @param string$companyName
+	 * @param string $phoneNumber
+	 * @param string|null$mobilePhoneNumber
+	 * @param string|null $email
+	 */
+	public function __construct($personName, $companyName, $phoneNumber, $mobilePhoneNumber, $email)
+	{
+		$this
+			->setPersonName($personName)
+			->setCompanyName($companyName)
+			->setPhoneNumber($phoneNumber);
+
+		if ($mobilePhoneNumber) {
+			$this->setMobilePhoneNumber($mobilePhoneNumber);
+		}
+
+		if ($email) {
+			$this->setEmailAddress($email);
+		}
+	}
 
     /**
      * Returns the person name.
@@ -78,6 +87,7 @@ class Contact
     public function setPersonName($personName)
     {
         $this->PersonName = new PersonName($personName);
+
         return $this;
     }
 
@@ -101,6 +111,7 @@ class Contact
     public function setCompanyName($companyName)
     {
         $this->CompanyName = new CompanyName($companyName);
+
         return $this;
     }
 
@@ -124,6 +135,7 @@ class Contact
     public function setPhoneNumber($phoneNumber)
     {
         $this->PhoneNumber = new PhoneNumber($phoneNumber);
+
         return $this;
     }
 
@@ -147,6 +159,7 @@ class Contact
     public function setEmailAddress($emailAddress)
     {
         $this->EmailAddress = new EmailAddress($emailAddress);
+
         return $this;
     }
 
@@ -170,6 +183,7 @@ class Contact
     public function setMobilePhoneNumber($mobilePhoneNumber)
     {
         $this->MobilePhoneNumber = new MobilePhoneNumber($mobilePhoneNumber);
+
         return $this;
     }
 }

--- a/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
+++ b/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
@@ -76,6 +76,7 @@ class ShipmentRequestMapper
 		/**
 		 * When using on demand delivery options then Buyer segment is required
 		 */
+		$buyerInfo = null;
 		if ($request->getOnDemandDeliveryServicePoint()) {
 			$buyerInfo = new Ship\BuyerContactInfo(
 				new Ship\Contact(

--- a/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
+++ b/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
@@ -72,13 +72,37 @@ class ShipmentRequestMapper
 			$shipmentInfo->setPaperlessTradeImage($request->getShipmentDetails()->getPaperlessEncodedStringDocument());
 		}
 
+		/**
+		 * When using on demand delivery options then Buyer segment is required
+		 */
+		if ($request->getOnDemandDeliveryOptions()) {
+			$buyerInfo = new Ship\BuyerContactInfo(
+				new Ship\Contact(
+					$request->getShipper()->getName(),
+					$request->getShipper()->getCompany(),
+					$request->getShipper()->getPhone(),
+					$request->getShipper()->getMobilePhone(),
+					$request->getShipper()->getEmail()
+				),
+				new Ship\BuyerAddress(
+					$request->getShipper()->getStreetLines()[0],
+					$request->getShipper()->getCity(),
+					$request->getShipper()->getPostalCode(),
+					$request->getShipper()->getCountryCode(),
+					$request->getShipper()->getStateOrProvince()
+				)
+			);
+		}
+
 		// Create ship
 		$ship = new Ship(
 			new Ship\ContactInfo(
 				new Ship\Contact(
 					$request->getShipper()->getName(),
 					$request->getShipper()->getCompany(),
-					$request->getShipper()->getPhone()
+					$request->getShipper()->getPhone(),
+					$request->getShipper()->getMobilePhone(),
+					$request->getShipper()->getEmail()
 				),
 				new Address(
 					$request->getShipper()->getStreetLines()[0],
@@ -92,7 +116,9 @@ class ShipmentRequestMapper
 				new Ship\Contact(
 					$request->getRecipient()->getName(),
 					$request->getRecipient()->getCompany(),
-					$request->getRecipient()->getPhone()
+					$request->getRecipient()->getPhone(),
+					$request->getRecipient()->getMobilePhone(),
+					$request->getRecipient()->getEmail()
 				),
 				new Address(
 					$request->getRecipient()->getStreetLines()[0],
@@ -101,7 +127,8 @@ class ShipmentRequestMapper
 					$request->getRecipient()->getCountryCode(),
 					$request->getRecipient()->getStateOrProvince()
 				)
-			)
+			),
+			$buyerInfo
 		);
 
 		$commodities = new InternationalDetail\Commodities(
@@ -193,6 +220,13 @@ class ShipmentRequestMapper
 		if ($shipmentInfo->getPaperlessTradeEnabled()) {
 			$paperlessService = new Service(ServiceType::TYPE_PAPERLESS);
 			$specialServicesList[] = $paperlessService;
+		}
+
+		if ($request->getOnDemandDeliveryOptions()) {
+			$requestedShipment->setOnDemandDeliveryOptions($request->getOnDemandDeliveryOptions());
+
+			$specialService = new Service(ServiceType::TYPE_ON_DEMAND_DELIVERY);
+			$specialServicesList[] = $specialService;
 		}
 
 		if (!empty($specialServicesList)) {

--- a/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
+++ b/src/Webservice/Soap/TypeMapper/ShipmentRequestMapper.php
@@ -19,6 +19,7 @@ use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\DangerousGoods;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\DangerousGoods\Content;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\InternationalDetail;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\InternationalDetail\ExportDeclaration;
+use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\OnDemandDeliveryOptions;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\Packages;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\Packages\RequestedPackages;
 use Dhl\Express\Webservice\Soap\Type\ShipmentRequest\RequestedShipment;
@@ -75,7 +76,7 @@ class ShipmentRequestMapper
 		/**
 		 * When using on demand delivery options then Buyer segment is required
 		 */
-		if ($request->getOnDemandDeliveryOptions()) {
+		if ($request->getOnDemandDeliveryServicePoint()) {
 			$buyerInfo = new Ship\BuyerContactInfo(
 				new Ship\Contact(
 					$request->getShipper()->getName(),
@@ -222,8 +223,18 @@ class ShipmentRequestMapper
 			$specialServicesList[] = $paperlessService;
 		}
 
-		if ($request->getOnDemandDeliveryOptions()) {
-			$requestedShipment->setOnDemandDeliveryOptions($request->getOnDemandDeliveryOptions());
+		if ($request->getOnDemandDeliveryServicePoint()) {
+			$onDemandDeliveryOptions = new OnDemandDeliveryOptions(
+				OnDemandDeliveryOptions\DeliveryOption::TV,
+				null,
+				null,
+				null,
+				null,
+				null,
+				$request->getOnDemandDeliveryServicePoint()
+			);
+
+			$requestedShipment->setOnDemandDeliveryOptions($onDemandDeliveryOptions);
 
 			$specialService = new Service(ServiceType::TYPE_ON_DEMAND_DELIVERY);
 			$specialServicesList[] = $specialService;

--- a/test/Unit/RequestBuilder/ShipmentRequestBuilderTest.php
+++ b/test/Unit/RequestBuilder/ShipmentRequestBuilderTest.php
@@ -49,6 +49,7 @@ class ShipmentRequestBuilderTest extends \PHPUnit\Framework\TestCase
                 $name = 'Max Mustermann',
                 $company = 'Acme',
                 $phone = '004922832432423',
+                $mobilePhone = '0038640566678',
                 $email = 'shipper@example.com'
             )
             ->setRecipient(
@@ -59,6 +60,7 @@ class ShipmentRequestBuilderTest extends \PHPUnit\Framework\TestCase
                 $name,
                 $company,
                 $phone,
+				$mobilePhone,
                 $email
             )
             ->setDryIce($unCode = 'UN1845', $weight = 20.53);


### PR DESCRIPTION
Added additional methods to set service point delivery option based on point ID.

New service type option has to be included and passed to the shipment request in order to generate correct label.
Also buyer contact info has to be passed for this option to be used.

Linked task:
https://eurosender.atlassian.net/browse/DEV-18054